### PR TITLE
Simplify navigation and enhance calculator contact step

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import Benefits from '@/components/Benefits';
 import Zones from '@/components/Zones';
 import Pricing from '@/components/Pricing';
 import Calculator from '@/components/Calculator';
-import Booking from '@/components/Booking';
 import Testimonials from '@/components/Testimonials';
 import Faq from '@/components/Faq';
 import Contact from '@/components/Contact';
@@ -42,7 +41,6 @@ const App: React.FC = () => {
                 <Zones />
                 <Pricing />
                 <Calculator />
-                <Booking />
                 <Testimonials />
                 <Faq />
                 <Contact />

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -73,6 +73,7 @@ const CalculatorForm: React.FC = () => {
       email: '',
       phone: '',
       missionDetail: detail,
+      appointmentDate: '',
       message: createMessage(detail),
     };
   });
@@ -129,8 +130,9 @@ const CalculatorForm: React.FC = () => {
   const handleContactSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const subject = `Demande d'informations - ${contact.missionDetail}`;
+    const summary = `Mission: ${state.mission}\nType de bien: ${state.typeBien}\nPrix total: ${total.toFixed(2)} €\nRésumé: ${state.chambres} ch., ${state.sdb} sdb, ${state.surface} m²`;
     const body = encodeURIComponent(
-      `Adresse du bien: ${contact.propertyAddress}\nNom et prénom: ${contact.fullName}\nEmail: ${contact.email}\nTéléphone: ${contact.phone}\n\n${contact.message}`
+      `${summary}\nDate souhaitée: ${contact.appointmentDate}\nAdresse du bien: ${contact.propertyAddress}\nNom et prénom: ${contact.fullName}\nEmail: ${contact.email}\nTéléphone: ${contact.phone}\n\n${contact.message}`
     );
     window.location.href = `mailto:Info@kdexpertise.be?subject=${encodeURIComponent(
       subject
@@ -168,6 +170,20 @@ const CalculatorForm: React.FC = () => {
         <CalculatorStepper currentStep={currentStep} />
         <div className="bg-white p-6 rounded-lg shadow-inner">
           <h4 className="text-xl font-bold text-blue-deep mb-4 text-center">Prendre contact</h4>
+          <div className="mb-4 p-4 bg-blue-deep/5 rounded text-sm text-slate-600">
+            <p>
+              <strong>Type de mission :</strong> {state.mission}
+            </p>
+            <p>
+              <strong>Type de bien :</strong> {state.typeBien}
+            </p>
+            <p>
+              <strong>Prix total :</strong> {total.toFixed(2)} €
+            </p>
+            <p>
+              <strong>Résumé :</strong> {state.chambres} ch., {state.sdb} sdb, {state.surface} m²
+            </p>
+          </div>
           <form onSubmit={handleContactSubmit} className="space-y-4 max-w-xl mx-auto">
             <input
               type="text"
@@ -216,6 +232,17 @@ const CalculatorForm: React.FC = () => {
                 </option>
               ))}
             </select>
+            <input
+              type="datetime-local"
+              name="appointmentDate"
+              value={contact.appointmentDate}
+              onChange={handleContactChange}
+              className="w-full p-3 border border-gray-300 rounded-lg"
+              required
+            />
+            <p className="text-xs text-slate-500">
+              L'expert essayera de caler le rendez-vous à cette date mais il se peut qu'il soit déjà occupé.
+            </p>
             <textarea
               name="message"
               value={contact.message}

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -33,9 +33,7 @@ import {
 export const NAV_LINKS: NavLink[] = [
   { name: 'Services', href: '#Services' },
   { name: 'Tarifs', href: '#Pricing' },
-  { name: 'Prendre RDV', href: '#Booking' },
   { name: 'Calculateur', href: '#Calculator' },
-  { name: 'Contact', href: '#Contact' },
 ];
 
 export const SERVICES: Service[] = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,5 +133,6 @@ export interface CalculatorContact {
     email: string;
     phone: string;
     missionDetail: string;
+    appointmentDate: string;
     message: string;
 }


### PR DESCRIPTION
## Summary
- remove duplicate Contact and booking links from navigation
- drop booking section from the app layout
- expand calculator contact step with summary info and appointment date field

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689999892aa8832eae5bcd5bb04952a8